### PR TITLE
Reformat tor proxy method

### DIFF
--- a/manga-batch-downloader.py
+++ b/manga-batch-downloader.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import docker
 from src.mangadex_downloader import MangadexDownloader
+from datetime import datetime
 
 # Initialize client variable
 client = None
@@ -23,41 +24,107 @@ def check_for_docker():
         sys.exit(1)
 
 
+<<<<<<< Updated upstream
 def check_and_pull_image(image_name):
     # Check if the proper Docker image is available, and if not pull it
     try:
         client.images.get(image_name)
     except docker.errors.ImageNotFound:
         print(f"Docker image '{image_name}' not found locally. Pulling from Docker Hub...")
+=======
+# noinspection PyUnresolvedReferences
+def check_and_pull_images(image_names):
+    for image_name in image_names:
+        # Check if the proper Docker image is available, and if not pull it
+>>>>>>> Stashed changes
         try:
-            # Pull from Docker Hub
-            client.images.pull(image_name)
-            print(f"Successfully pulled '{image_name}' from Docker Hub, moving on...")
-        except docker.errors.APIerror as e:
-            print(f"Error pulling image '{image_name}': {str(e)}")
-            sys.exit(1)
+            client.images.get(image_name)
+        except docker.errors.ImageNotFound:
+            print(f"Docker image '{image_name}' not found locally. Pulling from Docker Hub...")
+            try:
+                # Pull from Docker Hub
+                client.images.pull(image_name)
+                print(f"Successfully pulled '{image_name}' from Docker Hub, moving on...")
+            except docker.errors.APIerror as e:
+                print(f"Error pulling image '{image_name}': {str(e)}")
+                sys.exit(1)
+
+
+# Check for required containers that we need to be running
+def check_for_container(container):
+    try:
+        # Check to see if the torproxy image is running
+        result = subprocess.run(["docker", "ps -a"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if container in result.stdout:
+            print(f"Confirmed container {container} running...")
+            return True
+        else:
+            print(f"WARNING: Container {container} not running...")
+            return False
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: Unable to check for running container {container}: {str(e)}")
+        return False
+
+
+# noinspection PyUnresolvedReferences
+def start_container(container, container_name, container_args):
+    try:
+        container_start = download_client = client.containers.run(
+                container,  # Docker Image name
+                detach=True,  # Run in detached mode
+                name=container_name,  # Name of Container instance
+                remove=True,  # Remove after container process stops
+                command=container_args
+        )
+        print(
+            f"Started container '{container_name}' @ {datetime.now().strftime('%H:%M:%S')} with ID: "
+            f"{container_start.id}")
+        return container_name  # Return for tracking
+    except docker.errors.APIError as e:
+        print(f"Error starting container '{container_name}': {str(e)}")
+        return None
 
 
 def main():
     # Check if Docker is installed
     check_for_docker()
 
+    # Gather a list of docker images we need to run the tool
+    required_images = ["hillmanation/mangadex-downloader-tor", "dperson/torproxy"]
+
     # Check for the image we need and pull it down if we don't have it
-    check_and_pull_image("mansuf/mangadex-downloader")
+    check_and_pull_images(required_images)
 
     # Parse command-line arguments
     parser = argparse.ArgumentParser(description="Manga Downloader Script")
-    parser.add_argument('--export-dir', type=str, required=True, help="Local directory to save downloaded "
-                                                                      "manga to.")
+    parser.add_argument('--export-dir', type=str, required=True, help="Local directory to save downloaded manga to.")
     parser.add_argument('--manga-list', type=str, default='assets/manga-list.txt',
                         help="Path to manga list file, the default is included with this repository.")
     parser.add_argument('--max-containers', type=int, default=4,
                         help="Maximum number of simultaneous containers to spin up to run the batch downloads. Use "
                              "only as many containers as you're comfortable with. And probably less than the number "
                              "of cores your machine has.")
-    parser.add_argument('--torify-it', action='store_true',
+    parser.add_argument('--torify-it', type=str, default=None,
                         help="Anonymize the container over TOR network to hide from those that would block our WAN IP.")
     args = parser.parse_args()
+
+    # If proxy is requested and torproxy is not running let's configure the tor network and start it
+    if args.torify_it and not check_for_container("dperson/torproxy"):
+        try:
+            net_check = subprocess.run(["docker", "network ls"], check=True, stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE)
+            if "tor" in net_check:
+                print(f"Tor container network exists, starting torproxy on Tor network...")
+                start_container("dperson/torproxy", "tor_proxy", "--network tor -p9050:9050")
+            else:
+                print(f"Creating tor container network...")
+                subprocess.run(["docker", "network create tor"], check=True, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+                print(f"Tor container network created, starting torproxy on Tor network...")
+                start_container("dperson/torproxy", "tor_proxy", "--network tor -p9050:9050")
+        except subprocess.CalledProcessError as e:
+            print(f"Error: {str(e)} please manually create these before proceeding with tor proxy download settings...")
+            sys.exit(0)
 
     # Create a MangaDownloader instance with the provided export directory
     downloader = MangadexDownloader(

--- a/scripts/pull_Manga-Batch-Downloader.sh
+++ b/scripts/pull_Manga-Batch-Downloader.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Path to repository
+REPO_DIR="/root/manga-scripts/Manga-Batch-Downloader"
+
+# Navigate to REPO_DIR
+cd $REPO_DIR || { echo "Repository not found"; exit 1; }
+
+# Fetch the latest changes from the repository
+echo "Fetching changes from GitHub..."
+git pull origin main || { echo "Git pull failed"; exit 1; }
+
+# Install/Update Python dependencies
+if [ -f "requirements.txt" ]; then
+        echo "Installing/Updating Python dependencies..."
+        pip3 install -r requirements.txt || { echo "Failed to install dependencies"; exit 1; }
+fi

--- a/scripts/update_manga_libraries.sh
+++ b/scripts/update_manga_libraries.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+SCRIPT_DIR="/root/manga-scripts"
+DOWNLOADS="/sauce/manga_cbz"
+LOG_FILE="/var/log/manga_downloader.log"
+MANGA_FILE="assets/manga_list.txt"
+MAX_CON=6
+
+# Log the start time of the script
+echo "[$(date)] Starting manga batch download process" >> $LOG_FILE
+
+# Update the Manga Downloader repository
+if $SCRIPT_DIR/pull_Manga-Batch-Downloader.sh; then
+        echo "[$(date)] Manga-Batch-Downloader repo updated" >> $LOG_FILE
+fi
+
+# Navigate to the batch downloader directory
+cd $SCRIPT_DIR/Manga-Batch-Downloader || { echo "[$(date)] Failed to navigate to $SCRIPT_DIR/Manga-Batch-Downloader\nDoes this directory exist?" >> $LOG_FILE; exit 1; }
+
+# Run the batch download script
+if python3 manga-batch-downloader.py --export-dir $DOWNLOADS --manga-list $MANGA_FILE --max-containers $MAX_CON --torify-it sock55://tor_proxy:9050; then
+        echo "[$(date)] Started the batch download tasks..." >> $LOG_FILE
+else
+        echo "[$(date)] Failed to start the manga batch download process..." >> $LOG_FILE
+        exit 1
+fi
+
+# Log the end time of the script
+echo "[$(date)] Manga batch download process completed" >> $LOG_FILE

--- a/src/mangadex_downloader.py
+++ b/src/mangadex_downloader.py
@@ -29,47 +29,6 @@ class MangadexDownloader:
 
     # Start download container instance
     def start_download(self, instance_name, command_args):
-<<<<<<< Updated upstream
-        if self.torify_it:  # If torify is requested we have to start the container with subprocess
-            docker_command = [  # Build the command line arguments
-                "torsocks", "docker", "run",  # Run docker with the torsocks wrapper
-                "--detach",
-                "--name", instance_name,
-                "--volume", f"{self.volume_mapping}:/downloads:rw",
-                "--rm",
-                "mansuf/mangadex-downloader"
-            ] + command_args.split()  # Append the url and default arguments from {self.defaults}
-
-            try:  # Call subprocess to start the torified container
-                print(f"Torify it: Starting download of {instance_name}")
-                result = subprocess.run(' '.join(docker_command), check=True, shell=True, stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE)  # Use a shell for the subprocess so this actually works
-                print(
-                    f"Started container '{instance_name}' with torsocks: {self.torify_it} @ "
-                    f"{datetime.now().strftime('%H:%M:%S')} with ID: {result.stdout.decode()}")
-                return instance_name
-            except subprocess.CalledProcessError as e:
-                print(f"Error starting container '{instance_name}' with torsocks: {e.stderr.decode()}")
-                return None
-        else:
-            # Start a Docker container for downloading manga from a url without torify using python module method
-            try:
-                download_client = self.client.containers.run(
-                    "mansuf/mangadex-downloader",  # Docker Image name
-                    detach=True,  # Run in detached mode
-                    name=instance_name,  # Name of Container instance
-                    volumes={self.volume_mapping: {"bind": "/downloads", "mode": "rw"}},  # Local volume mapping
-                    remove=True,  # Remove after container process stops
-                    command=command_args
-                )
-                print(
-                    f"Started container '{instance_name}' @ {datetime.now().strftime('%H:%M:%S')} with ID: "
-                    f"{download_client.id}")
-                return instance_name  # Return for tracking
-            except docker.errors.APIError as e:
-                print(f"Error starting container '{instance_name}': {str(e)}")
-                return None
-=======
         try:
             download_client = self.client.containers.run(
                 "hillmanation/mangadex-downloader-tor",  # Docker Image name
@@ -86,7 +45,6 @@ class MangadexDownloader:
         except docker.errors.APIError as e:
             print(f"Error starting container '{instance_name}': {str(e)}")
             return None
->>>>>>> Stashed changes
 
     # Read in list of manga from a file
     def read_manga_list(self):

--- a/src/mangadex_downloader.py
+++ b/src/mangadex_downloader.py
@@ -1,5 +1,4 @@
 import docker
-import subprocess
 import time
 import re
 from datetime import datetime
@@ -30,6 +29,7 @@ class MangadexDownloader:
 
     # Start download container instance
     def start_download(self, instance_name, command_args):
+<<<<<<< Updated upstream
         if self.torify_it:  # If torify is requested we have to start the container with subprocess
             docker_command = [  # Build the command line arguments
                 "torsocks", "docker", "run",  # Run docker with the torsocks wrapper
@@ -69,6 +69,24 @@ class MangadexDownloader:
             except docker.errors.APIError as e:
                 print(f"Error starting container '{instance_name}': {str(e)}")
                 return None
+=======
+        try:
+            download_client = self.client.containers.run(
+                "hillmanation/mangadex-downloader-tor",  # Docker Image name
+                detach=True,  # Run in detached mode
+                name=instance_name,  # Name of Container instance
+                volumes={self.volume_mapping: {"bind": "/downloads", "mode": "rw"}},  # Local volume mapping
+                remove=True,  # Remove after container process stops
+                command=command_args
+            )
+            print(
+                f"Started container '{instance_name}' @ {datetime.now().strftime('%H:%M:%S')} with ID: "
+                f"{download_client.id}")
+            return instance_name  # Return for tracking
+        except docker.errors.APIError as e:
+            print(f"Error starting container '{instance_name}': {str(e)}")
+            return None
+>>>>>>> Stashed changes
 
     # Read in list of manga from a file
     def read_manga_list(self):
@@ -111,6 +129,8 @@ class MangadexDownloader:
         for manga_url in manga_list:
             container_name = valid_container_name(manga_url)
             command_args = f"{manga_url} {self.defaults}"
+            if self.torify_it:  # If proxy is requested add that setting here
+                command_args = f"{command_args} {self.torify_it}"
 
             name = self.start_download(container_name, command_args)
             if name:


### PR DESCRIPTION
'torsocks' was not working with the docker command even though it's supposed to fail if it cannot provide proper masking. This is a redesign of that method using the builtin not well documented '--proxy' flag provided by mansuf/mangadex-downloader original script that I forked into hillmanation/mangadex-downloader-tor to add some functionality to provides the end user confirmation that they are downloading over a proxy. This method not pulls that alternate docker image, as well as pulls the dperson/torproxy docker image and configures it for use on a dedicated container tor network so that the socks5 proxy will work properly in the download containers.